### PR TITLE
Revert "Revert "mediacodec: minijail: Enable exporting of policy files""

### DIFF
--- a/services/mediacodec/minijail/Android.mk
+++ b/services/mediacodec/minijail/Android.mk
@@ -21,7 +21,7 @@ ifneq (,$(wildcard $(BOARD_SECCOMP_POLICY)/mediacodec-seccomp.policy))
     LOCAL_SRC_FILES += $(BOARD_SECCOMP_POLICY)/mediacodec-seccomp.policy
 endif
 
-#include $(BUILD_SYSTEM)/base_rules.mk
+include $(BUILD_SYSTEM)/base_rules.mk
 
 $(LOCAL_BUILT_MODULE): $(LOCAL_SRC_FILES)
 	@mkdir -p $(dir $@)

--- a/services/mediaextractor/minijail/Android.mk
+++ b/services/mediaextractor/minijail/Android.mk
@@ -22,7 +22,7 @@ ifneq (,$(wildcard $(BOARD_SECCOMP_POLICY)/mediaextractor-seccomp.policy))
     LOCAL_SRC_FILES += $(BOARD_SECCOMP_POLICY)/mediaextractor-seccomp.policy
 endif
 
-#include $(BUILD_SYSTEM)/base_rules.mk
+include $(BUILD_SYSTEM)/base_rules.mk
 
 $(LOCAL_BUILT_MODULE): $(LOCAL_SRC_FILES)
 	@mkdir -p $(dir $@)


### PR DESCRIPTION
This reverts commit eae5335a5a7e1187d6572cd95b10a59020cc16b3.

Change-Id: I89dde58527ae5c5ffecad537bdd5774219a7ed69

[daedroza]: This shouldn't be allowed. This is as good as giving permissive builds ;)